### PR TITLE
Fix "admin:admin" b64 encoding issue

### DIFF
--- a/vendor-logins.json
+++ b/vendor-logins.json
@@ -275,7 +275,7 @@
             "Accept-Encoding": "gzip, deflate, br",
             "Accept-Language": "en-GB,en-US;q=0.9,en;q=0.8",
             "Connection": "close",
-            "Authorization": "Basic YWRtaW46YWRtaW4=="
+            "Authorization": "Basic YWRtaW46YWRtaW4="
           },
         "method": "GET"
         },


### PR DESCRIPTION
I noticed that the base64 encoding of `admin:admin` has an extra `=` at the end which. This PR removes it so it decodes correctly.